### PR TITLE
Add MessageStore support Quorum Queue, by adding a QueueType

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/QueueType.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/store/impl/rabbitmq/QueueType.java
@@ -1,0 +1,27 @@
+package org.apache.synapse.message.store.impl.rabbitmq;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum QueueType {
+    QUORUM("quorum"),
+    CLASSIC("classic");
+
+    public final String type;
+
+    private QueueType(String type) {
+        this.type = type;
+    }
+
+    private static final Map<String, QueueType> TYPE_MAP = Arrays.stream(QueueType.values())
+            .collect(Collectors.toMap(queueType -> queueType.type.toLowerCase(), queueType -> queueType));
+
+    public static QueueType fromType(String type) {
+        QueueType queueType = TYPE_MAP.get(type.toLowerCase());
+        if (queueType == null) {
+            throw new IllegalArgumentException("No QueueType with type: " + type);
+        }
+        return queueType;
+    }
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: 
The MessageStore does not support RabbitMQ Quorum Queue

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above
Add a new parameter call QueueType to identify either it's a Classic or Quorum Queue, and add this parameter during the declaration Queue phase.